### PR TITLE
Fix wrong option name for `display-name`

### DIFF
--- a/src/Openl10n/Bundle/UserBundle/Command/CreateUserCommand.php
+++ b/src/Openl10n/Bundle/UserBundle/Command/CreateUserCommand.php
@@ -61,7 +61,7 @@ class CreateUserCommand extends ContainerAwareCommand
 
         // Ask for display name
         $defaultDisplayName = ucfirst($username);
-        $input->setOption('username', $dialog->askAndValidate(
+        $input->setOption('display-name', $dialog->askAndValidate(
             $output,
             'Display name ['.$defaultDisplayName.']: ',
             $validation('displayName'),


### PR DESCRIPTION
This resulted in an error when creating a user from command line:

> There are some errors:
> - displayName: This value should not be blank.
