### PR TITLE
Add Sass in requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ PHP dependencies are managed via Composer:
     curl -sS https://getcomposer.org/installer | php
     composer.phar install
 
+Gulp need to have Sass installed (which requires Ruby):
+
+    gem install sass
+
 Assets are compiled using Gulp (which requires Node and NPM):
 
     # Install node and npm on your system, then run


### PR DESCRIPTION
Fix this error with gulp:

> Warning: You need to have Ruby and Sass installed and in your PATH for this task to work.
