### PR TITLE
Hotfix/php54 empty

### DIFF
--- a/src/Openl10n/Bundle/ApiBundle/Facade/TranslationCommit.php
+++ b/src/Openl10n/Bundle/ApiBundle/Facade/TranslationCommit.php
@@ -64,7 +64,7 @@ class TranslationCommit
         $this->sourceLocale = (string) $source->getLocale();
         $this->targetPhrase = (string) $target->getText();
         $this->targetLocale = (string) $target->getLocale();
-        $this->isTranslated = !empty($target->getText());
+        $this->isTranslated = !empty($this->targetPhrase);
         $this->isApproved = $target->isApproved();
     }
 }


### PR DESCRIPTION
```
$ php -l src/Openl10n/Bundle/ApiBundle/Facade/TranslationCommit.php 
PHP Fatal error:  Can't use method return value in write context in src/Openl10n/Bundle/ApiBundle/Facade/TranslationCommit.php on line 67

Fatal error: Can't use method return value in write context in src/Openl10n/Bundle/ApiBundle/Facade/TranslationCommit.php on line 67
Errors parsing src/Openl10n/Bundle/ApiBundle/Facade/TranslationCommit.php
```
