### PR TITLE
Add a stage1 configuration file

### DIFF
--- a/.stage1.yml
+++ b/.stage1.yml
@@ -1,0 +1,19 @@
+build:
+  - mysqladmin create openl10n
+  - apt-get update -y
+  - apt-get install -y software-properties-common python-software-properties python g++ make
+  - apt-add-repository ppa:chris-lea/node.js
+  - apt-get update -y
+  - apt-get install -y nodejs
+  - composer install --ansi --no-progress --dev --prefer-dist --no-interaction
+  - app/console doctrine:schema:update --force
+  - app/console assets:install web/
+  - app/console doctrine:fixtures:load --env=dev --no-interaction
+  - npm install
+  - npm install -g gulp bower
+  - bower install --allow-root
+  - gulp build --prod
+ 
+writable:
+  - app/logs
+  - app/cache


### PR DESCRIPTION
This configuration enable to use [stage1.io](http://stage1.io/) service.

Documentation about this configuration file:
http://help.stage1.io/article/customizing-a-build-with-the-build-yml-file/

Note that it could be use outside the sources of the project (http://help.stage1.io/article/using-a-build-yml-without-adding-it-to-my-sources/). However I prefer integrate it to verion control to dispatch any changes
with an update of the project installation.

This file is a copy of the original config suggestion of @ubermuda (https://gist.github.com/ubermuda/bbac8b7f392508feb087) for openl10n (https://twitter.com/ubermuda/status/481774170926510080).
