### PR TITLE
correction export resources format. xliff => xlf

### DIFF
--- a/src/Openl10n/Bundle/ApiBundle/Controller/ResourceController.php
+++ b/src/Openl10n/Bundle/ApiBundle/Controller/ResourceController.php
@@ -276,7 +276,7 @@ class ResourceController extends BaseController implements ClassResourceInterfac
      *     },
      *     filters={
      *         { "name"="locale", "dataType"="choice", "required"="true" },
-     *         { "name"="format", "dataType"="choice", "required"="true", "format"="{'csv', 'ini', 'json', 'mo', 'php', 'po', 'ts', 'xliff', 'yml'}" },
+     *         { "name"="format", "dataType"="choice", "required"="true", "format"="{'csv', 'ini', 'json', 'mo', 'php', 'po', 'ts', 'xlf', 'yml'}" },
      *         { "name"="options", "dataType"="choice", "required"="false", "format"="{'reviewed':'Mark translations as reviewed', 'erase':'Ecrase same values', 'clean':'Clean unused values'}" }
      *     }
      * )


### PR DESCRIPTION
The export resources at xliff format doesn't existe. 
Symfony has just xlf alias for dumper "translation.dumper.xliff". 
This correction allows export to xlf format.
