### PR TITLE
Entity constraint names collisions

### DIFF
--- a/src/Openl10n/Bundle/InfraBundle/Resources/config/doctrine/Key.orm.xml
+++ b/src/Openl10n/Bundle/InfraBundle/Resources/config/doctrine/Key.orm.xml
@@ -8,7 +8,7 @@
         repository-class="Openl10n\Bundle\InfraBundle\Repository\TranslationRepository"
         >
         <unique-constraints>
-            <unique-constraint name="idx_hash" columns="resource_id,hash" />
+            <unique-constraint name="idx_hashkey" columns="resource_id,hash" />
         </unique-constraints>
 
         <id name="id" type="integer" column="id">

--- a/src/Openl10n/Bundle/UserBundle/Resources/config/doctrine/User.orm.xml
+++ b/src/Openl10n/Bundle/UserBundle/Resources/config/doctrine/User.orm.xml
@@ -7,7 +7,7 @@
             repository-class="Openl10n\Bundle\UserBundle\Repository\UserRepository">
 
         <unique-constraints>
-            <unique-constraint name="slug" columns="username" />
+            <unique-constraint name="user_slug" columns="username" />
         </unique-constraints>
 
         <id name="id" type="integer" column="id">


### PR DESCRIPTION
When you install the project and create the database (with postgresql at least), there is a conflict with two constraints names: idx_hash and slug. The problem can be fixed in the User.orm.xml and Key.orm.xml.