### PR TITLE
Added filter "identifier" to translations cget API method

### DIFF
--- a/src/Openl10n/Bundle/ApiBundle/Controller/TranslationController.php
+++ b/src/Openl10n/Bundle/ApiBundle/Controller/TranslationController.php
@@ -38,16 +38,18 @@ class TranslationController extends BaseController implements ClassResourceInter
      * @Rest\QueryParam(name="project", strict=true, nullable=false)
      * @Rest\QueryParam(name="page", requirements="\d+", default="1", strict=true, nullable=false, description="Page number")
      * @Rest\QueryParam(name="per_page", requirements="\d+", default="2000", strict=true, nullable=false, description="Item per page")
+     * @Rest\QueryParam(name="identifier", description="Translation's identifier")
      * @Rest\View
      */
     public function cgetAction(ParamFetcher $paramFetcher)
     {
         $page = (int) $paramFetcher->get('page');
         $perPage = (int) $paramFetcher->get('per_page');
+        $identifier = $paramFetcher->get('identifier');
 
         $project = $this->findProjectOr404($paramFetcher->get('project'));
 
-        $specification = new TranslationByProjectSpecification($project);
+        $specification = new TranslationByProjectSpecification($project, $identifier);
 
         $pager = $this->get('openl10n.repository.translation')->findSatisfying($specification);
         $pager->setMaxPerPage($perPage);

--- a/src/Openl10n/Bundle/InfraBundle/Specification/TranslationByProjectSpecification.php
+++ b/src/Openl10n/Bundle/InfraBundle/Specification/TranslationByProjectSpecification.php
@@ -8,15 +8,18 @@ use Openl10n\Domain\Translation\Model\Key;
 use Openl10n\Domain\Translation\Specification\DoctrineOrmTranslationSpecification;
 
 /**
- * Retrieve all translations (with all their phrases) by a project
+ * Retrieve all translations (with all their phrases) by a project, and eventually an identifier
  */
 class TranslationByProjectSpecification implements DoctrineOrmTranslationSpecification
 {
     protected $project;
 
-    public function __construct(Project $project)
+    protected $identifier;
+
+    public function __construct(Project $project, $identifier = '')
     {
         $this->project = $project;
+        $this->identifier = $identifier;
     }
 
     public function isSatisfiedBy(Key $translationKey)
@@ -34,5 +37,9 @@ class TranslationByProjectSpecification implements DoctrineOrmTranslationSpecifi
                 'project' => $this->project
             ))
         ;
+
+        if ($this->identifier) {
+            $queryBuilder->andWhere('k.identifier = :identifier')->setParameter('identifier', $this->identifier);
+        }
     }
 }


### PR DESCRIPTION
Hi Matthieu,

We're using openl10n in our company, and sometimes we push wrong translations which stay eternally on the server. We needed a command tool to definitely erase them, so I allowed myself to implement it :)

In order to delete a translation, I had to get it, to know its id in database. To respect the REST api, and not override the get method, I added an optional "identifier" filter in the cget method.
